### PR TITLE
Add new repository for integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -103,3 +103,9 @@ repositories:
       identus-admins: admin
       identus-maintainers: maintain
     visibility: public
+  - name: integration
+    teams:
+      bots: admin
+      identus-admins: admin
+      identus-maintainers: maintain
+    visibility: public


### PR DESCRIPTION
The Identus Team needs another repository to run the end-to-end integration tests