### PR TITLE
Add repository prism-vdr-driver

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -120,3 +120,9 @@ repositories:
       identus-admins: admin
       identus-maintainers: maintain
     visibility: public
+  - name: prism-vdr-driver
+    teams:
+      bots: admin
+      identus-admins: admin
+      identus-maintainers: maintain
+    visibility: public


### PR DESCRIPTION
The new repository `prism-vdr-driver` is added to the organization for DID PRISM VDR driver implementation.