### PR TITLE
Add pparker (Jon Pokroy) to maintainer lists

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ teams:
       - curtis-h
       - mineme0110
       - patextreme
+      - pparker
   - name: identus-maintainers
     maintainers:
       - yshyn-iohk
@@ -26,6 +27,7 @@ teams:
       - jesusdiazvico
       - mineme0110
       - patextreme
+      - pparker
       - robertocarvajal
       - coveloper
       - bsandmann


### PR DESCRIPTION
[pparker](https://github.com/pparker) is Jon Pokroy. I asked him to help me managing and updating the https://github.com/orgs/hyperledger-identus/projects/2

He just needs access to the board. I'm just not sure if the group `identus-maintainers` was permission to change the board (ex add/remove columns, move tickets around, etc). I would try to doublecheck with @ryjones