### PR TITLE
Add identity-portal repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,7 @@ teams:
       - bsandmann
       - Yummy-Yums
       - TeoSL87
+      - TheSeydiCharyyev
   - name: staff
     maintainers:
       - ryjones

--- a/config.yaml
+++ b/config.yaml
@@ -146,3 +146,9 @@ repositories:
       identus-admins: admin
       identus-maintainers: maintain
     visibility: private
+  - name: identity-portal
+    teams:
+      bots: admin
+      identus-admins: admin
+      identus-maintainers: maintain
+    visibility: public


### PR DESCRIPTION
The identity-portal repository is a new home for the Identity Portal initiative under the LFDT Mentorship program 2026